### PR TITLE
Fix short exon vanishing at the 3' edge of a collapsed exon block (BoxRenderer.getTile)

### DIFF
--- a/Gedi/src/gedi/gui/genovis/tracks/boxrenderer/BoxRenderer.java
+++ b/Gedi/src/gedi/gui/genovis/tracks/boxrenderer/BoxRenderer.java
@@ -247,7 +247,13 @@ public class BoxRenderer<D> {
 		boolean rtl = locationMapper.is5to3() && reference.getStrand()==Strand.Minus;
 		double x1 = rtl?locationMapper.bpToPixel(reference,end):locationMapper.bpToPixel(reference,start);
 		double x2 = rtl?locationMapper.bpToPixel(reference,start):locationMapper.bpToPixel(reference,end);
-		Rectangle2D.Double tile = new Rectangle2D.Double(xOffset+x1,y,x2-x1,h);
+		// x1<x2 is not guaranteed: when a short exon abuts the 3' end of a compressed block (e.g. with
+		// collapsed introns) bpToPixel(start) can overshoot bpToPixel(end), giving a zero/negative width.
+		// Java2D treats such a Rectangle2D as empty and draws neither fill nor border, so the box
+		// vanishes completely. Normalize the order and keep at least one pixel so it stays visible.
+		double left = Math.min(x1, x2);
+		double width = Math.max(Math.abs(x2-x1), 1);
+		Rectangle2D.Double tile = new Rectangle2D.Double(xOffset+left,y,width,h);
 		return tile;
 	}
 


### PR DESCRIPTION
## Problem

In the genome browser / RiboView, double-clicking a consensus exon track collapses the
introns. A very short exon that sits right at the **3' end of a consensus exon block** then
disappears completely — not just its color fill, the darkGray border box too.

Originally seen on `homo_sapiens.90`, track `Orfs_Rp-Bp.locations`, region
`2:200810593-200827338`: the ORF `2+:200812307-200812309|...` has a 2 bp first exon at the
3' edge of consensus exon `200812184-200812309`, and that box vanishes on collapse.

## Root cause

`PixelBasepairMapper.PixelBasePairRange.bpToPixel` spreads a range's bases over
`pixelStop - pixelStart + 1` pixels, so a base near a compressed block's 3' end maps
slightly *past* the block edge. A rendered exon's exclusive `end` coordinate, however,
falls into the next (intron) range and maps to that shared boundary pixel (the block's
right edge). For a short exon at the 3' edge this makes `x1 > x2`, so in
`BoxRenderer.getTile` the width `x2 - x1` is negative (measured ≈ −0.6 px in the original
case). A `Rectangle2D` with width ≤ 0 is `isEmpty()`, and Java2D draws neither fill nor
border → the whole box disappears. It only bites very short exons at a block boundary under
intron collapse (~0.19 px/bp there).

`getTile` is the single shared method every box track inherits (location / ORF / transcript
/ narrowpeak renderers), so this one change covers them all. `StackedBoxesTrack` builds its
own rects and is unaffected.

## Fix

```diff
 	boolean rtl = locationMapper.is5to3() && reference.getStrand()==Strand.Minus;
 	double x1 = rtl?locationMapper.bpToPixel(reference,end):locationMapper.bpToPixel(reference,start);
 	double x2 = rtl?locationMapper.bpToPixel(reference,start):locationMapper.bpToPixel(reference,end);
-	Rectangle2D.Double tile = new Rectangle2D.Double(xOffset+x1,y,x2-x1,h);
+	// x1<x2 is not guaranteed: when a short exon abuts the 3' end of a compressed block (e.g. with
+	// collapsed introns) bpToPixel(start) can overshoot bpToPixel(end), giving a zero/negative width.
+	// Java2D treats such a Rectangle2D as empty and draws neither fill nor border, so the box
+	// vanishes completely. Normalize the order and keep at least one pixel so it stays visible.
+	double left = Math.min(x1, x2);
+	double width = Math.max(Math.abs(x2-x1), 1);
+	Rectangle2D.Double tile = new Rectangle2D.Double(xOffset+left,y,width,h);
 	return tile;
```

## Minimal reproducer (openable in the gedi browser)

A tiny synthetic genome with two `+` strand transcripts reproduces it without any real data:

```
CONSENSUS : 1+:1000-21000 | 40000-40100      one big consensus exon block + a far exon
ORF2BP    : 1+:20998-21000 | 40000-40050      a 2 bp first exon at the block's 3' edge
```

Build and open (needs a built gedi and a display; set `GEDI` to the launcher):

```bash
GEDI=/path/to/Gedi/gedi
mkdir repro && cd repro

# 1) genome: one contig chr1, 41 kb (sequence content is irrelevant)
python3 - <<'PY'
n=41000; s=("ACGT"*((n//4)+1))[:n]
open("genome.fasta","w").write(">chr1\n"+"\n".join(s[i:i+60] for i in range(0,n,60))+"\n")
PY

# 2) the gene track (GTF is 1-based; internal gedi coords are start-1)
cat > genome.gtf <<'GTF'
chr1	repro	exon	1001	21000	.	+	.	gene_id "CONSENSUS"; transcript_id "CONSENSUS"; gene_biotype "protein_coding"; transcript_biotype "protein_coding";
chr1	repro	exon	40001	40100	.	+	.	gene_id "CONSENSUS"; transcript_id "CONSENSUS"; gene_biotype "protein_coding"; transcript_biotype "protein_coding";
chr1	repro	exon	20999	21000	.	+	.	gene_id "ORF2BP"; transcript_id "ORF2BP"; gene_biotype "protein_coding"; transcript_biotype "protein_coding";
chr1	repro	exon	40001	40050	.	+	.	gene_id "ORF2BP"; transcript_id "ORF2BP"; gene_biotype "protein_coding"; transcript_biotype "protein_coding";
GTF

# 3) index into a genome descriptor ./boxbug
"$GEDI" -e IndexGenome -s "$PWD/genome.fasta" -a "$PWD/genome.gtf" \
        -n boxbug -o "$PWD/boxbug" -nobowtie -nostar -nokallisto -nomapping

# 4) viewer pipeline: the consensus exon track collapsed via SmartLayout
cat > viewer.oml <<OML
<Pipeline>
  <Genomic.get id="genomic" names="$PWD/boxbug" />
  <StorageSource id="+.trans" filter="+"><Transcripts st="genomic" /></StorageSource>
  <ChromosomesTrack suffix="+" id="+.Chromosomes"><Height h="25" /></ChromosomesTrack>
  <PositionTrack id="+.Positions"><Height h="20" /></PositionTrack>
  <PackRegionTrack input="+.trans" id="+.Transcripts">
    <Hspace space="0" /><Background c="#CCCCCC" />
    <BoxRenderer><TranscriptRenderer/></BoxRenderer>
    <SmartLayout smart="true" />
    <ViewDoubleClick />
  </PackRegionTrack>
</Pipeline>
OML

# 5) open at 1:900-40200 with introns already collapsed
"$GEDI" -e Display -oml "$PWD/viewer.oml" -g "$PWD/boxbug" -l 1:900-40200
```

On the **ORF2BP** row, the small box at the **3' (right) edge** of the big `CONSENSUS` exon
block is **missing** without this fix and a **thin box** with it — everything else (the far
exon and the connecting intron line) renders identically.

The same geometry, checked headlessly through the real `PixelBasepairMapper` +
`BoxRenderer.getTile` (viewer width 1900 px → collapsed scale ~0.094 px/bp): old width
`x2 - x1 = -0.81 px`, `Rectangle2D.isEmpty() == true` before the fix; a visible 1 px box
after.
